### PR TITLE
Add CDN latency monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ module "azurerm_front_door_waf" {
 | [azurerm_cdn_frontdoor_rule_set.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_monitor_metric_alert.cdn_latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
@@ -86,11 +87,14 @@ module "azurerm_front_door_waf" {
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_host_add_response_headers"></a> [cdn\_host\_add\_response\_headers](#input\_cdn\_host\_add\_response\_headers) | List of response headers to add at the CDN Front Door `[{ "Name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | `[]` | no |
 | <a name="input_cdn_host_redirects"></a> [cdn\_host\_redirects](#input\_cdn\_host\_redirects) | CDN FrontDoor host redirects `[{ "from" = "example.com", "to" = "www.example.com" }]` | `list(map(string))` | `[]` | no |
+| <a name="input_cdn_latency_monitor_threshold"></a> [cdn\_latency\_monitor\_threshold](#input\_cdn\_latency\_monitor\_threshold) | CDN latency monitor threshold in milliseconds | `number` | `5000` | no |
 | <a name="input_cdn_remove_response_headers"></a> [cdn\_remove\_response\_headers](#input\_cdn\_remove\_response\_headers) | List of response headers to remove at the CDN Front Door | `list(string)` | `[]` | no |
 | <a name="input_cdn_response_timeout"></a> [cdn\_response\_timeout](#input\_cdn\_response\_timeout) | Azure CDN Front Door response timeout in seconds | `number` | `120` | no |
 | <a name="input_cdn_sku"></a> [cdn\_sku](#input\_cdn\_sku) | Azure CDN Front Door SKU | `string` | `"Standard_AzureFrontDoor"` | no |
 | <a name="input_cdn_waf_targets"></a> [cdn\_waf\_targets](#input\_cdn\_waf\_targets) | Target endpoints to configure the WAF to point towards | <pre>map(<br>    object({<br>      domain : string,<br>      create_custom_domain : optional(bool, false),<br>      enable_health_probe : optional(bool, true),<br>      health_probe_interval : optional(number, 60),<br>      health_probe_request_type : optional(string, "HEAD"),<br>      health_probe_path : optional(string, "/")<br>    })<br>  )</pre> | `{}` | no |
+| <a name="input_enable_cdn_latency_monitor"></a> [enable\_cdn\_latency\_monitor](#input\_enable\_cdn\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_existing_monitor_action_group_id"></a> [existing\_monitor\_action\_group\_id](#input\_existing\_monitor\_action\_group\_id) | ID of an existing monitor action group | `string` | `""` | no |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Conditionally launch resources into an existing resource group. Specifying this will NOT create a resource group. | `string` | `""` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -16,5 +16,9 @@ locals {
   cdn_host_add_response_headers = var.cdn_host_add_response_headers
   cdn_remove_response_headers   = var.cdn_remove_response_headers
 
+  existing_monitor_action_group_id = var.existing_monitor_action_group_id
+  enable_cdn_latency_monitor       = var.enable_cdn_latency_monitor
+  cdn_latency_monitor_threshold    = var.cdn_latency_monitor_threshold
+
   tags = var.tags
 }

--- a/monitor.tf
+++ b/monitor.tf
@@ -1,0 +1,25 @@
+resource "azurerm_monitor_metric_alert" "cdn_latency" {
+  count = local.enable_cdn_latency_monitor && local.existing_monitor_action_group_id != "" ? 1 : 0
+
+  name                = "${azurerm_cdn_frontdoor_profile.waf.name}-latency"
+  resource_group_name = local.resource_group.name
+  scopes              = [azurerm_cdn_frontdoor_profile.waf.id]
+  description         = "Action will be triggered when Origin latency is higher than ${local.cdn_latency_monitor_threshold}ms"
+  window_size         = "PT5M"
+  frequency           = "PT5M"
+  severity            = 2
+
+  criteria {
+    metric_namespace = "Microsoft.Cdn/profiles"
+    metric_name      = "TotalLatency"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = local.cdn_latency_monitor_threshold
+  }
+
+  action {
+    action_group_id = local.existing_monitor_action_group_id
+  }
+
+  tags = local.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,21 @@ variable "cdn_remove_response_headers" {
   type        = list(string)
   default     = []
 }
+
+variable "existing_monitor_action_group_id" {
+  description = "ID of an existing monitor action group"
+  type        = string
+  default     = ""
+}
+
+variable "enable_cdn_latency_monitor" {
+  description = "Enable CDN latency monitor"
+  type        = bool
+  default     = false
+}
+
+variable "cdn_latency_monitor_threshold" {
+  description = "CDN latency monitor threshold in milliseconds"
+  type        = number
+  default     = 5000
+}


### PR DESCRIPTION
* Creates a monitor metric alert, based on the CDN TotalLatency - with a configurable threshold
* Currently the ID of an existing action group must be provided