### PR TITLE
Add WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,59 @@ module "azurerm_front_door_waf" {
     },
   }
 
+  enable_waf                            = true
+  waf_mode                              = "Prevention"
+  waf_enable_rate_limiting              = true
+  waf_rate_limiting_duration_in_minutes = 1
+  waf_rate_limiting_threshold           = 300
+  waf_rate_limiting_bypass_ip_list      = [
+    "8.8.8.8"
+  ]
+  waf_rate_limiting_action = "Block"
+  waf_managed_rulesets     = {
+    "BotProtection" = {
+      version = "preview-0.1",
+      action  = "Block"
+    },
+    "DefaultRuleSet" = {
+      version = "1.0",
+      action  = "Block",
+      overrides = {
+        "SQL" = {
+          "942110" = {
+            action = "Log"
+          },
+          "942150" = {
+            action = "Log",
+            exclusions = {
+              "my-test-exclusion" = {
+                match_variable = "RequestCookieNames",
+                operator = "StartsWith",
+                selector = "Foo"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  waf_custom_rules = {
+    "PostParamValuesfoo" = {
+      priority = 10,
+      action = "Allow",
+      match_conditions = {
+        "allow-any-foo" = {
+          match_variable = "PostArgs",
+          match_values = []
+          operator = "Any",
+          selector = "foo"
+        }
+      }
+    }
+  }
+  waf_custom_block_response_status_code = 403
+  waf_custom_block_response_body = filebase64("my-error-page.html")
+
   tags = {
     "Environment"      = "Dev"
   }
@@ -66,6 +119,7 @@ module "azurerm_front_door_waf" {
 | [azurerm_cdn_frontdoor_custom_domain.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
 | [azurerm_cdn_frontdoor_endpoint.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
+| [azurerm_cdn_frontdoor_firewall_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_firewall_policy) | resource |
 | [azurerm_cdn_frontdoor_origin.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin) | resource |
 | [azurerm_cdn_frontdoor_origin_group.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
 | [azurerm_cdn_frontdoor_profile.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
@@ -76,6 +130,7 @@ module "azurerm_front_door_waf" {
 | [azurerm_cdn_frontdoor_rule_set.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_cdn_frontdoor_security_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
 | [azurerm_monitor_metric_alert.cdn_latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
@@ -93,11 +148,22 @@ module "azurerm_front_door_waf" {
 | <a name="input_cdn_sku"></a> [cdn\_sku](#input\_cdn\_sku) | Azure CDN Front Door SKU | `string` | `"Standard_AzureFrontDoor"` | no |
 | <a name="input_cdn_waf_targets"></a> [cdn\_waf\_targets](#input\_cdn\_waf\_targets) | Target endpoints to configure the WAF to point towards | <pre>map(<br>    object({<br>      domain : string,<br>      create_custom_domain : optional(bool, false),<br>      enable_health_probe : optional(bool, true),<br>      health_probe_interval : optional(number, 60),<br>      health_probe_request_type : optional(string, "HEAD"),<br>      health_probe_path : optional(string, "/")<br>    })<br>  )</pre> | `{}` | no |
 | <a name="input_enable_cdn_latency_monitor"></a> [enable\_cdn\_latency\_monitor](#input\_enable\_cdn\_latency\_monitor) | Enable CDN latency monitor | `bool` | `false` | no |
+| <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable CDN Front Door WAF | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_monitor_action_group_id"></a> [existing\_monitor\_action\_group\_id](#input\_existing\_monitor\_action\_group\_id) | ID of an existing monitor action group | `string` | `""` | no |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Conditionally launch resources into an existing resource group. Specifying this will NOT create a resource group. | `string` | `""` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
+| <a name="input_waf_custom_block_response_body"></a> [waf\_custom\_block\_response\_body](#input\_waf\_custom\_block\_response\_body) | Base64 encoded custom response body when the WAF blocks a request | `string` | `""` | no |
+| <a name="input_waf_custom_block_response_status_code"></a> [waf\_custom\_block\_response\_status\_code](#input\_waf\_custom\_block\_response\_status\_code) | Custom response status code when the WAF blocks a request. | `number` | `0` | no |
+| <a name="input_waf_custom_rules"></a> [waf\_custom\_rules](#input\_waf\_custom\_rules) | Map of all Custom rules you want to apply to the WAF | <pre>map(object({<br>    priority : number,<br>    action : string,<br>    match_conditions : map(object({<br>      match_variable : string,<br>      match_values : list(string),<br>      operator : string,<br>      selector : optional(string, null)<br>    }))<br>  }))</pre> | `{}` | no |
+| <a name="input_waf_enable_rate_limiting"></a> [waf\_enable\_rate\_limiting](#input\_waf\_enable\_rate\_limiting) | Deploy a Rate Limiting Policy on the Front Door WAF | `bool` | `false` | no |
+| <a name="input_waf_managed_rulesets"></a> [waf\_managed\_rulesets](#input\_waf\_managed\_rulesets) | Map of all Managed rules you want to apply to the WAF, including any overrides | <pre>map(object({<br>    version : string,<br>    action : string,<br>    exclusions : optional(map(object({<br>      match_variable : string,<br>      operator : string,<br>      selector : string<br>    })), {})<br>    overrides : optional(map(map(object({<br>      action : string,<br>      exclusions : optional(map(object({<br>        match_variable : string,<br>        operator : string,<br>        selector : string<br>      })), {})<br>    }))), {})<br>  }))</pre> | `{}` | no |
+| <a name="input_waf_mode"></a> [waf\_mode](#input\_waf\_mode) | CDN Front Door WAF mode | `string` | `"Prevention"` | no |
+| <a name="input_waf_rate_limiting_action"></a> [waf\_rate\_limiting\_action](#input\_waf\_rate\_limiting\_action) | Action to take when rate limiting (Block/Log) | `string` | `"Block"` | no |
+| <a name="input_waf_rate_limiting_bypass_ip_list"></a> [waf\_rate\_limiting\_bypass\_ip\_list](#input\_waf\_rate\_limiting\_bypass\_ip\_list) | List if IP CIDRs to bypass the Rate Limit Policy | `list(string)` | `[]` | no |
+| <a name="input_waf_rate_limiting_duration_in_minutes"></a> [waf\_rate\_limiting\_duration\_in\_minutes](#input\_waf\_rate\_limiting\_duration\_in\_minutes) | Number of minutes to BLOCK requests that hit the Rate Limit threshold | `number` | `1` | no |
+| <a name="input_waf_rate_limiting_threshold"></a> [waf\_rate\_limiting\_threshold](#input\_waf\_rate\_limiting\_threshold) | Maximum number of concurrent requests before Rate Limiting policy is applied | `number` | `300` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -20,5 +20,17 @@ locals {
   enable_cdn_latency_monitor       = var.enable_cdn_latency_monitor
   cdn_latency_monitor_threshold    = var.cdn_latency_monitor_threshold
 
+  enable_waf                            = var.enable_waf
+  waf_managed_rulesets                  = var.waf_managed_rulesets
+  waf_custom_rules                      = var.waf_custom_rules
+  waf_mode                              = var.waf_mode
+  waf_custom_block_response_status_code = var.waf_custom_block_response_status_code
+  waf_custom_block_response_body        = var.waf_custom_block_response_body
+  waf_enable_rate_limiting              = var.waf_enable_rate_limiting
+  waf_rate_limiting_duration_in_minutes = var.waf_rate_limiting_duration_in_minutes
+  waf_rate_limiting_threshold           = var.waf_rate_limiting_threshold
+  waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
+  waf_rate_limiting_action              = var.waf_rate_limiting_action
+
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,94 @@ variable "cdn_latency_monitor_threshold" {
   type        = number
   default     = 5000
 }
+
+variable "enable_waf" {
+  description = "Enable CDN Front Door WAF"
+  type        = bool
+  default     = false
+}
+
+variable "waf_mode" {
+  description = "CDN Front Door WAF mode"
+  type        = string
+  default     = "Prevention"
+}
+
+variable "waf_enable_rate_limiting" {
+  description = "Deploy a Rate Limiting Policy on the Front Door WAF"
+  type        = bool
+  default     = false
+}
+
+variable "waf_rate_limiting_duration_in_minutes" {
+  description = "Number of minutes to BLOCK requests that hit the Rate Limit threshold"
+  type        = number
+  default     = 1
+}
+
+variable "waf_rate_limiting_threshold" {
+  description = "Maximum number of concurrent requests before Rate Limiting policy is applied"
+  type        = number
+  default     = 300
+}
+
+variable "waf_rate_limiting_bypass_ip_list" {
+  description = "List if IP CIDRs to bypass the Rate Limit Policy"
+  type        = list(string)
+  default     = []
+}
+
+variable "waf_rate_limiting_action" {
+  description = "Action to take when rate limiting (Block/Log)"
+  type        = string
+  default     = "Block"
+}
+
+variable "waf_managed_rulesets" {
+  description = "Map of all Managed rules you want to apply to the WAF, including any overrides"
+  type = map(object({
+    version : string,
+    action : string,
+    exclusions : optional(map(object({
+      match_variable : string,
+      operator : string,
+      selector : string
+    })), {})
+    overrides : optional(map(map(object({
+      action : string,
+      exclusions : optional(map(object({
+        match_variable : string,
+        operator : string,
+        selector : string
+      })), {})
+    }))), {})
+  }))
+  default = {}
+}
+
+variable "waf_custom_rules" {
+  description = "Map of all Custom rules you want to apply to the WAF"
+  type = map(object({
+    priority : number,
+    action : string,
+    match_conditions : map(object({
+      match_variable : string,
+      match_values : list(string),
+      operator : string,
+      selector : optional(string, null)
+    }))
+  }))
+  default = {}
+}
+
+variable "waf_custom_block_response_status_code" {
+  description = "Custom response status code when the WAF blocks a request."
+  type        = number
+  default     = 0
+}
+
+variable "waf_custom_block_response_body" {
+  description = "Base64 encoded custom response body when the WAF blocks a request"
+  type        = string
+  default     = ""
+}

--- a/waf.tf
+++ b/waf.tf
@@ -1,0 +1,144 @@
+resource "azurerm_cdn_frontdoor_firewall_policy" "waf" {
+  name                              = "${replace(local.resource_prefix, "-", "")}waf"
+  resource_group_name               = local.resource_group.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.waf.sku_name
+  enabled                           = local.enable_waf
+  mode                              = local.waf_mode
+  custom_block_response_status_code = local.waf_custom_block_response_status_code != 0 ? local.waf_custom_block_response_status_code : null
+  custom_block_response_body        = local.waf_custom_block_response_body != "" ? local.waf_custom_block_response_body : null
+
+  dynamic "custom_rule" {
+    for_each = local.waf_enable_rate_limiting ? [1] : []
+
+    content {
+      name                           = "RateLimiting"
+      enabled                        = true
+      priority                       = 1
+      rate_limit_duration_in_minutes = local.waf_rate_limiting_duration_in_minutes
+      rate_limit_threshold           = local.waf_rate_limiting_threshold
+      type                           = "RateLimitRule"
+      action                         = local.waf_rate_limiting_action
+
+      dynamic "match_condition" {
+        for_each = length(local.waf_rate_limiting_bypass_ip_list) > 0 ? [1] : []
+
+        content {
+          match_variable     = "RemoteAddr"
+          operator           = "IPMatch"
+          negation_condition = true
+          match_values       = local.waf_rate_limiting_bypass_ip_list
+        }
+      }
+
+      match_condition {
+        match_variable     = "RequestUri"
+        operator           = "RegEx"
+        negation_condition = false
+        match_values       = ["/.*"]
+      }
+    }
+  }
+
+  dynamic "custom_rule" {
+    for_each = local.waf_custom_rules
+
+    content {
+      name     = custom_rule.key
+      enabled  = true
+      priority = custom_rule.value["priority"]
+      type     = "MatchRule"
+      action   = custom_rule.value["action"]
+
+      dynamic "match_condition" {
+        for_each = custom_rule.value["match_conditions"]
+
+        content {
+          match_variable = match_condition.value["match_variable"]
+          match_values   = match_condition.value["match_values"]
+          operator       = match_condition.value["operator"]
+          selector       = match_condition.value["selector"]
+        }
+      }
+    }
+  }
+
+  dynamic "managed_rule" {
+    for_each = local.waf_managed_rulesets
+
+    content {
+      type    = managed_rule.key
+      version = managed_rule.value["version"]
+      action  = managed_rule.value["action"]
+
+      dynamic "exclusion" {
+        for_each = managed_rule.value["exclusions"]
+
+        content {
+          match_variable = exclusion.value["match_variable"]
+          operator       = exclusion.value["operator"]
+          selector       = exclusion.value["selector"]
+        }
+      }
+
+      dynamic "override" {
+        for_each = managed_rule.value["overrides"]
+
+        content {
+          rule_group_name = override.key
+
+          dynamic "rule" {
+            for_each = override.value
+
+            content {
+              rule_id = rule.key
+              enabled = true
+              action  = rule.value["action"]
+
+              dynamic "exclusion" {
+                for_each = rule.value["exclusions"]
+
+                content {
+                  match_variable = exclusion.value["match_variable"]
+                  operator       = exclusion.value["operator"]
+                  selector       = exclusion.value["selector"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  tags = local.tags
+}
+
+resource "azurerm_cdn_frontdoor_security_policy" "waf" {
+  name                     = "${replace(local.resource_prefix, "-", "")}wafsecuritypolicy"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.waf.id
+
+  security_policies {
+    firewall {
+      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.waf.id
+
+      association {
+        patterns_to_match = ["/*"]
+
+        dynamic "domain" {
+          for_each = local.cdn_waf_targets
+
+          content {
+            cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.waf[domain.key].id
+          }
+        }
+
+        dynamic "domain" {
+          for_each = local.cdn_custom_domains
+
+          content {
+            cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.waf[domain.key].id
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Conditonally enable Rate limiting
* Conditionally add custom and managed rulesets
* Conditionally add a custom response
* Defaults to Prevention mode, but can be changed
* This is added to all configured `cdn_waf_targets`