### PR TITLE
Add WAF logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ module "azurerm_front_door_waf" {
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_security_policy.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
+| [azurerm_log_analytics_workspace.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_diagnostic_setting.waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.cdn_latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -1,0 +1,31 @@
+resource "azurerm_log_analytics_workspace" "waf" {
+  name                = "${local.resource_prefix}waf"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = local.tags
+}
+
+resource "azurerm_monitor_diagnostic_setting" "waf" {
+  name                           = "${local.resource_prefix}waf"
+  target_resource_id             = azurerm_cdn_frontdoor_profile.waf.id
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.waf.id
+  log_analytics_destination_type = "AzureDiagnostics"
+
+  enabled_log {
+    category = "FrontdoorWebApplicationFirewallLog"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}


### PR DESCRIPTION
* Creates a diagnostic setting to send the FrontDoor WebApplicationFirewall logs from the CDN profile
* Creates an analytics workspace to store logs from diagnostic settings